### PR TITLE
Add intellij-idea-ultimate-edition with jre to repo

### DIFF
--- a/aur-packages
+++ b/aur-packages
@@ -847,3 +847,5 @@ zypper-git
 etcd
 riemann
 virt-what
+intellij-idea-ultimate-edition
+intellij-idea-ultimate-edition-jre


### PR DESCRIPTION
This adds intellij-idea-ultimate-edition and the intellij-idea-ultimate-edition-jre (jre with patches for intellij) to the repo