### PR TITLE
Copy file directly without Artifact Deployer

### DIFF
--- a/create_subjobs.groovy
+++ b/create_subjobs.groovy
@@ -25,16 +25,9 @@ PackagesFile.eachLine { line ->
       shell("sudo /usr/bin/makechrootpkg -u -c -r /mnt/aur/build_test -l ${packageName}")
     }
     publishers {
-      artifactDeployer {
-        artifactsToDeploy {
-          includes('*.pkg.tar.*')
-          remoteFileLocation("/var/lib/jenkins/packages/")
-          failIfNoFiles()
-          deleteRemoteArtifacts()
-        }
-      }
       postBuildScripts {
         steps {
+          shell('cp "${WORKSPACE}/"*.pkg.tar.* /var/lib/jenkins/packages/')
           shell("/usr/local/bin/copy-and-cleanup ${packageName}");
         }
         onlyIfBuildSucceeds(true)


### PR DESCRIPTION
Artifact Deployer removed in version 1.2 the ability to use it in the
dsl script.

So, we need to replace Artifact Deployer