### PR TITLE
Fix: remove fixed job name

### DIFF
--- a/create_subjobs.groovy
+++ b/create_subjobs.groovy
@@ -1,6 +1,5 @@
 // add a useless comment to trigger a diff to trigger a commit to trigger a PR to trigger a mass rebuild
-def PackagesFile = new File('/var/lib/jenkins/jobs/Arch Package Builder/workspace/aur-packages')
-PackagesFile.eachLine { line ->
+readFileFromWorkspace('aur-packages').eachLine { line ->
   packageName = line.trim()
   job("Arch_Package_${packageName}") {
     description("This Job builds the ${packageName} package for archlinux")


### PR DESCRIPTION
Currently the create_subjobs.groovy script needs a fix procject name.

This PR fix this and uses build-in methods to get the right part