### PR TITLE
add bcache-tools package

### DIFF
--- a/aur-packages
+++ b/aur-packages
@@ -13,6 +13,7 @@ asciinema
 atom-editor
 atom-editor-bin
 aurvote
+bcache-tools
 brscan3
 budgie-desktop-git
 burp-backup-git


### PR DESCRIPTION
aur/bcache-tools builds just fine so we can add it to automated builds and push it to the mirror