### PR TITLE
add libmodulemd1 to satisfy libdnf deps

### DIFF
--- a/aur-packages
+++ b/aur-packages
@@ -857,3 +857,4 @@ siji-git
 fswebcam
 yubico-yubioath-desktop
 wlroots-git
+libmodulemd1


### PR DESCRIPTION
The package `libdnf` depends on `libmodulemd1` which is currently not being built.