### PR TITLE
add python2-pysqlite for yum

### DIFF
--- a/aur-packages
+++ b/aur-packages
@@ -251,6 +251,7 @@ python2-power-git
 python2-puppetboard
 python-pykickstart
 python2-pypdf2
+python2-pysqlite
 python2-pysvn
 python2-tracing
 python2-ttystatus


### PR DESCRIPTION
appears to have been dropped from the repo to aur during the python2 removal.